### PR TITLE
Realtime data implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# CCG-Dev
+.vscode
+sslkeylogfile.txt

--- a/realtimeExample.py
+++ b/realtimeExample.py
@@ -22,27 +22,18 @@ _LOGGER = logging.getLogger(__name__)
 
 class MyDukeRT(DukeEnergyRealtime):
     """My instance of DukeEnergyRealtime"""
-    # def on_msg(self, client, userdata, msg):
-    #     """On Message callback.
+    def on_msg(self, msg):
+        """On Message callback.
 
-    #     Parameters
-    #     ----------
-    #     client : mqtt.Client
-    #         The paho-mqtt client
-    #     userdata
-    #         user data passed by the client
-    #     msg : MQTTMessage
-    #         This is a class with members topic, payload, qos, retain
-    #     """
-    #     _LOGGER.debug("my rx msg on %s\n%s", msg.topic, json.dumps(msg.payload.decode('utf8')))
-    #     if not self.rx_msg:
-    #         _LOGGER.warning("Unexpected message: %s", msg)
-    #     else:
-    #         self.rx_msg.set_result((msg.payload.decode("utf8")))
-    pass
+        Parameters
+        ----------
+        msg : MQTTMessage
+            This is a class with members topic, payload, qos, retain
+        """
+        _LOGGER.debug("my rx msg on %s\n%s", msg.topic, json.dumps(msg.payload.decode('utf8')))
+        
 
-
-async def main() -> None:  # noqa
+async def main() -> None:
     logging.basicConfig(level=logging.DEBUG)
 
     # Pull email/password into environment variables

--- a/realtimeExample.py
+++ b/realtimeExample.py
@@ -1,0 +1,74 @@
+"""Example of realtime power measurement."""
+
+# pylint: skip-file
+
+import asyncio
+import getpass
+import json
+import os
+import logging
+
+import aiohttp
+import sys
+
+from pyduke_energy.client import DukeEnergyClient
+from pyduke_energy.errors import DukeEnergyError
+from pyduke_energy.realtime import DukeEnergyRealtime
+
+PYDUKEENERGY_TEST_EMAIL = "PYDUKEENERGY_TEST_EMAIL"
+PYDUKEENERGY_TEST_PASS = "PYDUKEENERGY_TEST_PASS"
+
+_LOGGER = logging.getLogger(__name__)
+
+class MyDukeRT(DukeEnergyRealtime):
+    """My instance of DukeEnergyRealtime"""
+    # def on_msg(self, client, userdata, msg):
+    #     """On Message callback.
+
+    #     Parameters
+    #     ----------
+    #     client : mqtt.Client
+    #         The paho-mqtt client
+    #     userdata
+    #         user data passed by the client
+    #     msg : MQTTMessage
+    #         This is a class with members topic, payload, qos, retain
+    #     """
+    #     _LOGGER.debug("my rx msg on %s\n%s", msg.topic, json.dumps(msg.payload.decode('utf8')))
+    #     if not self.rx_msg:
+    #         _LOGGER.warning("Unexpected message: %s", msg)
+    #     else:
+    #         self.rx_msg.set_result((msg.payload.decode("utf8")))
+    pass
+
+
+async def main() -> None:  # noqa
+    logging.basicConfig(level=logging.DEBUG)
+
+    # Pull email/password into environment variables
+    email = os.environ.get(PYDUKEENERGY_TEST_EMAIL)
+    password = os.environ.get(PYDUKEENERGY_TEST_PASS)
+
+    if email is None or password is None:
+        print(
+            "Enter your email and password in environment variables. To avoid typing them in, you can put them into environment variables {PYDUKEENERGY_TEST_EMAIL} and {PYDUKEENERGY_TEST_PASS}."
+        )
+        email = input("Email: ")
+        password = getpass.getpass("Password: ")
+    try:
+        async with aiohttp.ClientSession() as client:
+            duke_energy = DukeEnergyClient(email, password, client)
+
+            duke_rt = MyDukeRT(duke_energy)
+
+            await duke_rt.connect_and_subscribe()
+
+    except DukeEnergyError as err:
+        print(err)
+
+if __name__ == "__main__":
+    # ensure selector event loop is started in windows
+    if sys.platform == 'win32':
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+    asyncio.run(main())

--- a/src/pyduke_energy/const.py
+++ b/src/pyduke_energy/const.py
@@ -3,5 +3,7 @@
 CUST_API_BASE_URL = "https://cust-api.duke-energy.com/gep/v2/"
 CUST_PILOT_API_BASE_URL = "https://cust-pilot-api.duke-energy.com/"
 IOT_API_BASE_URL = "https://app-core1.de-iot.io/rest/cloud/"
+MQTT_HOST = "app-core1.de-iot.io"
+MQTT_PORT = 443
 
 DEFAULT_TIMEOUT = 10  # seconds

--- a/src/pyduke_energy/realtime.py
+++ b/src/pyduke_energy/realtime.py
@@ -1,0 +1,236 @@
+"""Client for connecting to Duke Energy realtime stream."""
+
+import asyncio
+import logging
+import ssl
+
+import paho.mqtt.client as mqtt
+from pyduke_energy.client import DukeEnergyClient
+from pyduke_energy.const import(MQTT_HOST, MQTT_PORT)
+from pyduke_energy.errors import InputError
+
+_LOGGER = logging.getLogger(__name__)
+
+class DukeEnergyRealtime:
+    """Duke Energy Realtime Client."""
+    endpoint = "/app-mqtt"
+
+    def __init__(self,duke_energy:DukeEnergyClient):
+        self.duke_energy = duke_energy
+        self.loop = asyncio.get_event_loop()
+        self.disconnected = None
+        self.rx_msg = None
+        self.mqtt_client = None
+        self.topicid = None
+
+    def on_conn(self, client: mqtt.Client, _userdata, _flags, conn_res):
+        """On Connect callback.
+
+        Parameters
+        ----------
+        client : mqtt.Client
+            The paho-mqtt client
+        userdata
+            user data passed by the client
+        flags
+            Response flags sent by server
+        conn_res : connack_code
+            connection result code
+
+        This will call the client.subscribe() method if the connection was successful.
+        """
+        if conn_res:
+            _LOGGER.error("MQTT connection error with result code: %s", mqtt.connack_string(conn_res))
+        else:
+            _LOGGER.debug("MQTT connected with result code: %s", mqtt.connack_string(conn_res))
+            res = client.subscribe(self.topicid, qos=0)
+            if not res:
+                _LOGGER.warning("Subscribe error: %s",mqtt.error_string(res))
+
+    def on_sub(self, _client: mqtt.Client, _userdata, mid, granted_qos):
+        """On Subscribe callback.
+
+        Parameters
+        ----------
+        client : mqtt.Client
+            The paho-mqtt client
+        userdata
+            user data passed by the client
+        mid : int
+            message id#
+        granted_qos : literal[0, 1, 2]
+            qos level granted by the server
+        """
+        _LOGGER.debug(
+            "MQTT subscribed msg_id: %s qos: %s", str(mid), str(granted_qos)
+        )
+
+    def on_unsub(self, client: mqtt.Client, _userdata, mid):
+        """On Unubscribe callback.
+
+        Parameters
+        ----------
+        client : mqtt.Client
+            The paho-mqtt client
+        userdata
+            user data passed by the client
+        mid : int
+            message id#
+
+        This will call the client.disconnect() method
+        """
+        _LOGGER.debug("MQTT unsubscribed msg_id: %s", str(mid))
+        client.disconnect()
+
+    def on_discon(self, _client: mqtt.Client, _userdata, conn_res):
+        """On Disconnect callback.
+
+        Parameters
+        ----------
+        client : mqtt.Client
+            The paho-mqtt client
+        userdata
+            user data passed by the client
+        conn_res
+            Disconnect error code
+        """
+        if conn_res:
+            _LOGGER.error("MQTT disconnect error, result code: %s", mqtt.error_string(conn_res) )
+        else:
+            _LOGGER.debug("MQTT disconnected with result code: %s", mqtt.error_string(conn_res) )
+        self.disconnected.set_result(conn_res)
+
+    def on_msg(self, _client: mqtt.Client, _userdata, msg):
+        """On Message callback.
+
+        Parameters
+        ----------
+        client : mqtt.Client
+            The paho-mqtt client
+        userdata
+            user data passed by the client
+        msg : MQTTMessage
+            This is a class with members topic, payload, qos, retain
+        """
+        _LOGGER.debug("rx msg on %s\n%s", msg.topic, msg.payload.decode('utf8'))
+        if not self.rx_msg:
+            _LOGGER.warning("Unexpected message: %s", msg)
+        else:
+            self.rx_msg.set_result((msg.payload.decode("utf8")))
+
+    async def connect_and_subscribe(self):
+        """Mqtt client connection."""
+        self.disconnected = self.loop.create_future()
+        self.rx_msg = None
+        try:
+            headers = await self.duke_energy._get_gateway_auth_headers()
+        except InputError:
+            # Assume 1st meter in 1st account # if missing
+            _LOGGER.info("No meter specified, assuming fist meter of first accnt")
+            accounts = await self.duke_energy.get_account_list()
+            meters = await self.duke_energy.get_account_details(accounts[0])
+            self.duke_energy.select_meter(meters.meter_infos[0])
+            headers = await self.duke_energy._get_gateway_auth_headers()
+
+        mqtt_auth = await self.duke_energy._get_mqtt_auth()
+        self.topicid = f'DESH/{mqtt_auth["gateway"]}/out/sm/1/live'
+        userdata = {"mqtt_auth": mqtt_auth, "msgs": [], "nmsgs": 0, "topicid": self.topicid}
+
+        self.mqtt_client = mqtt.Client(
+            mqtt_auth["clientid"], transport="websockets", userdata=userdata
+        )
+        self.mqtt_client.on_connect = self.on_conn
+        self.mqtt_client.on_subscribe = self.on_sub
+        self.mqtt_client.on_unsubscribe = self.on_unsub
+        self.mqtt_client.on_disconnect = self.on_discon
+        self.mqtt_client.on_message = self.on_msg
+        self.mqtt_client.enable_logger(logger=_LOGGER)
+        self.mqtt_client.ws_set_options(path=self.endpoint, headers=headers)
+        self.mqtt_client.username_pw_set(
+            mqtt_auth["user"], password=mqtt_auth["pass"]
+        )
+        self.mqtt_client.reconnect_delay_set(3, 60)
+        # create default ssl context to get SSLKEYLOGFILE env variable
+        self.mqtt_client.tls_set_context(ssl.create_default_context())
+
+        MqttConnHelper(self.loop, self.mqtt_client)
+        self.mqtt_client.connect(MQTT_HOST, port=MQTT_PORT)
+        await self.duke_energy.start_smartmeter_fastpoll()
+
+        while True:
+            try:
+                await asyncio.sleep(1)
+                self.rx_msg = self.loop.create_future()
+                await self.rx_msg
+                self.rx_msg = None
+            except KeyboardInterrupt:
+                _LOGGER.info("Listening ended by user.")
+                break
+
+        res = self.mqtt_client.unsubscribe(self.topicid)
+        if not res:
+            _LOGGER.warning("Unsubscribe error: %s",mqtt.error_string(res))
+        await self.disconnected
+
+class MqttConnHelper:
+    """Helper for asyncio mqtt."""
+
+    def __init__(self, loop: asyncio.AbstractEventLoop, mqtt_client: mqtt.Client):
+        self.loop = loop
+        self.mqtt_client = mqtt_client
+        self.mqtt_client.on_socket_open = self.on_socket_open
+        self.mqtt_client.on_socket_close = self.on_socket_close
+        self.mqtt_client.on_socket_register_write = (
+            self.on_socket_register_write
+        )
+        self.mqtt_client.on_socket_unregister_write = (
+            self.on_socket_unregister_write
+        )
+        self.misc = None
+
+    def on_socket_open(self, client: mqtt.Client, _userdata, sock):
+        """Socket open callback."""
+        _LOGGER.debug("Socket opened")
+
+        def call_bk():
+            """Socket reader callback."""
+            _LOGGER.debug("Socket readable, calling loop_read()")
+            client.loop_read()
+
+        self.loop.add_reader(sock, call_bk)
+        self.misc = self.loop.create_task(self.misc_loop())
+
+    def on_socket_close(self, _client: mqtt.Client, _userdata, sock):
+        """Socket close callback."""
+        _LOGGER.debug("Socket closed")
+        self.loop.remove_reader(sock)
+        self.misc.cancel()
+
+    def on_socket_register_write(self, client: mqtt.Client, _userdata, sock):
+        """Socket write reg callback."""
+        _LOGGER.debug("Watching socket for writability.")
+
+        def call_bk():
+            """Socket write callback."""
+            _LOGGER.debug("Socket is writable, calling loop_write")
+            client.loop_write()
+
+        self.loop.add_writer(sock, call_bk)
+
+    def on_socket_unregister_write(self, _client: mqtt.Client, _userdata, sock):
+        """Socket unreg write callback."""
+        _LOGGER.debug("Stop watching socket for writability.")
+        self.loop.remove_writer(sock)
+
+    async def misc_loop(self):
+        """Misc loop call."""
+        _LOGGER.debug("Misc loop started")
+
+        while self.mqtt_client.loop_misc() == mqtt.MQTT_ERR_SUCCESS:
+            try:
+                await asyncio.sleep(1)
+            except asyncio.CancelledError:
+                break
+            except KeyboardInterrupt:
+                pass
+        _LOGGER.debug("Misc loop finished")


### PR DESCRIPTION
First off, I am new to python and opensource development and I have no idea what I don't know, so help me out if I'm missing anything and don't assume I know what I'm doing...

Anyway, I've been working on implementing the MQTT over websocket connection for streaming the real-time power usage data. That seems to be 1 msg per 3 seconds and contains a timestamp, the current power usage, and some accumulating counter, presumably power consumption. I think I have it basically functional, but I'm sure there's a lot of room for improvement. I guess I'm not sure how complete it should be before submitting a pull request, but it seems like a good stage to at least get some feedback. 

I had to update a handful of functions in the client.py to gather the relevant authentication info for the MQTT connection, and then add another request to start the fast polling on the smart meter. Then, I added a new script, realtime.py that handles the MQTT connection. That makes use of the paho-mqtt client library, [paho-mqtt](https://www.eclipse.org/paho/). This is done in a new class, `DukeEnergyRealtime`, which takes a `DukeEnergyClient` object as an input. I plan to subclass it in order to customize the `on_msg()` callback method to put the data in a database or whatever. The main method of this class is `connect_and_subscribe()` which will connect to the mqtt server and subscribe to the topic and run forever, as messages come in the `on_msg()` callback will be called. Ctrl-c can break out of this forever loop and will disconnect from the mqtt server first. There is a realtimeExample.py script that shows this. 

I came across a handful of issues while working on this. First, I started out working in a dev container, but something about that seemed to be setting the TCP_KEEPIDLE to 0 seconds so it would start sending TCP keepalive messages immediately. I'm not sure that's a real issue, but it seemed like a lot of unnecessary traffic and I struggled to adjust that. I ended up going to a virtual environment in vscode for my development which got around that issue. However, that highlighted that in windows, python 3.8+ switches the default loop for asyncio, so `asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())` is required before the `asyncio.run(main())` command.

Setting the SSLKEYLOGFILE environment variable to a writable text file is handy for decrypting the traffic with wireshark for instance (you can tell it where the keylogfile is in edit -> preferences -> protocol -> TLS -> (Pre)-Master-Secret log... Also, this wireshark plugin was very helpful [wireshark-mqtt-ws-plugin](https://github.com/nberthet/wireshark-mqtt-ws-plugin)

There are a handful of things I'm not fully happy with yet. First, when escaping from the loop it still throws a traceback even tho it does unsubscribe and disconnect as I intend. I'm not sure how to avoid that, or if it matters.

I don't yet have much error handling, nor do I know how long you can stream data for. I suspect it will eventually timeout, and I expect that the start fast poll request will need to be re-sent at some point. I think that the paho-mqtt library would try to reconnect, but that wouldn't request the fast polling again (due to the paho-mqtt callbacks not being asynchronous I cant await the fastpoll request there).

I'm not yet sure how well using subclassing to customize the on_msg callback will work in practice. While most of the paho-mqtt library is asynchronous, the callbacks are blocking. I think it will be OK in this particular case since the data rate is 1/3Hz but it doesn't feel like the right place to deal with the data. I'd love some suggestions on how best to handle that. 

My focus has been on something that could run continually to push the data into a db, so I haven't given much thought to other use-cases.

Anyway, let me know your feedback/thoughts/suggestions. 
Thanks,
Phil