### PR TITLE
Refactoring and indefinite reconnect (v1.0.0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ name: Tests
 
 on:
   push:
-    branches: [main]
   pull_request:
   schedule:
     - cron: "0 0 * * *"

--- a/examples/example_realtime.py
+++ b/examples/example_realtime.py
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 class MyDukeRT(DukeEnergyRealtime):
     """My instance of DukeEnergyRealtime."""
 
-    def on_msg(self, msg):
+    def on_message(self, msg):
         """On Message callback.
 
         Parameters

--- a/examples/example_realtime.py
+++ b/examples/example_realtime.py
@@ -66,7 +66,7 @@ async def main() -> None:
 
             duke_rt = MyDukeRT(duke_energy)
             await duke_rt.select_default_meter()
-            await duke_rt.connect_and_subscribe()
+            await duke_rt.connect_and_subscribe_forever()
     except DukeEnergyError as err:
         print(err)
 

--- a/examples/example_realtime_kafka.py
+++ b/examples/example_realtime_kafka.py
@@ -14,7 +14,7 @@ from kafka import KafkaProducer
 from kafka.errors import KafkaTimeoutError
 
 from pyduke_energy.client import DukeEnergyClient
-from pyduke_energy.const import FASTPOLL_TIMEOUT
+from pyduke_energy.const import FASTPOLL_TIMEOUT_SEC
 from pyduke_energy.errors import DukeEnergyError
 from pyduke_energy.realtime import DukeEnergyRealtime
 
@@ -39,7 +39,7 @@ class MyDukeRT(DukeEnergyRealtime):
             self.kfk.close()
             _LOGGER.debug("Disconnected from Kafka")
 
-    def on_msg(self, msg):
+    def on_message(self, msg):
         """On Message callback.
 
         Parameters
@@ -85,14 +85,14 @@ async def main() -> None:
                 duke_rt = MyDukeRT(duke_energy)
                 duke_rt.connect_kafka("smartmeter")
                 await duke_rt.select_default_meter()
-                await duke_rt.connect_and_subscribe()
+                await duke_rt.connect_and_subscribe_forever()
         except DukeEnergyError as err:
             # attempt sleep and retry
             _LOGGER.warning("Error: %s\nAttempt sleep and retry.", err)
             await duke_rt.mqtt_client.unsubscribe()
             duke_rt.close_kafka()
 
-            time.sleep(FASTPOLL_TIMEOUT)
+            time.sleep(FASTPOLL_TIMEOUT_SEC)
         finally:
             duke_rt.close_kafka()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyduke-energy
-version = 0.0.15
+version = 1.0.0
 author = Michael Meli
 author_email = mjmeli94@gmail.com
 description = Python Wrapper for unofficial Duke Energy REST API

--- a/src/pyduke_energy/client.py
+++ b/src/pyduke_energy/client.py
@@ -433,7 +433,7 @@ class DukeEnergyClient:
             ) from timeout_err
         except ClientError as client_err:
             raise RequestError(
-                f"Request failed with unexpected error [{full_url}]: {client_err}"
+                f"Request failed with unexpected error [{full_url}]: ({client_err.__class__.__name__}) {client_err}"
             ) from client_err
         finally:
             if not use_running_session:

--- a/src/pyduke_energy/client.py
+++ b/src/pyduke_energy/client.py
@@ -75,8 +75,8 @@ class _GatewayAuthInfo(_BaseAuthInfo):
         self.id_token: Optional[str] = None
         self.mqtt_username: Optional[str] = None
         self.mqtt_password: Optional[str] = None
-        self.mqtt_clientid: Optional[str] = None
-        self.mqtt_clientid_error: Optional[str] = None
+        self.mqtt_client_id: Optional[str] = None
+        self.mqtt_client_id_error: Optional[str] = None
         self.gateway: Optional[str] = None
 
 
@@ -372,8 +372,8 @@ class DukeEnergyClient:
         self._gateway_auth_info.id_token = resp.get("id_token")
         self._gateway_auth_info.mqtt_username = resp.get("mqtt_username")
         self._gateway_auth_info.mqtt_password = resp.get("mqtt_password")
-        self._gateway_auth_info.mqtt_clientid = resp.get("mqtt_clientId")
-        self._gateway_auth_info.mqtt_clientid_error = resp.get("mqtt_clientId_error")
+        self._gateway_auth_info.mqtt_client_id = resp.get("mqtt_clientId")
+        self._gateway_auth_info.mqtt_client_id_error = resp.get("mqtt_clientId_error")
         self._gateway_auth_info.gateway = resp.get("gateway")
 
     async def _get_gateway_auth_headers(self) -> dict:
@@ -392,7 +392,7 @@ class DukeEnergyClient:
         if self._gateway_auth_info.needs_new_access_token():
             await self._gateway_login()
         return {
-            "clientid": self._gateway_auth_info.mqtt_clientid,
+            "clientid": self._gateway_auth_info.mqtt_client_id,
             "user": self._gateway_auth_info.mqtt_username,
             "pass": self._gateway_auth_info.mqtt_password,
             "gateway": self._gateway_auth_info.gateway,

--- a/src/pyduke_energy/const.py
+++ b/src/pyduke_energy/const.py
@@ -20,4 +20,10 @@ FASTPOLL_TIMEOUT = 900 - 3  # seconds
 FASTPOLL_RETRY = 60  # if no messages after this time, retry fastpoll request
 FASTPOLL_RETRY_COUNT = 3
 
+# in minutes, minimum amount of time to wait before retrying connection on forever loop
+FOREVER_RETRY_BASE_MIN_MINUTES = 1
+
+# in minutes, maximum amount of time to wait before trying connection on forever loop
+FOREVER_RETRY_BASE_MAX_MINUTES = 60
+
 DEFAULT_TIMEOUT = 10  # seconds

--- a/src/pyduke_energy/const.py
+++ b/src/pyduke_energy/const.py
@@ -29,10 +29,10 @@ MESSAGE_TIMEOUT_SEC = 60
 MESSAGE_TIMEOUT_RETRY_COUNT = 3
 
 # in minutes, minimum amount of time to wait before retrying connection on forever loop
-FOREVER_RETRY_BASE_MIN_MINUTES = 1
+FOREVER_RETRY_MIN_MINUTES = 1
 
 # in minutes, maximum amount of time to wait before trying connection on forever loop
-FOREVER_RETRY_BASE_MAX_MINUTES = 60
+FOREVER_RETRY_MAX_MINUTES = 60
 
 # in seconds, how long to wait for a connection before timing out
 CONNECT_TIMEOUT_SEC = 60

--- a/src/pyduke_energy/const.py
+++ b/src/pyduke_energy/const.py
@@ -12,13 +12,21 @@ ACCT_DET_ENDPOINT = "auth/account-details"
 GW_STATUS_ENDPOINT = "gw/gateways/status"
 GW_USAGE_ENDPOINT = "smartmeter/usageByHour"
 
+DEFAULT_TIMEOUT = 10  # seconds
+
 MQTT_HOST = "app-core1.de-iot.io"
 MQTT_PORT = 443
 MQTT_ENDPOINT = "/app-mqtt"
 MQTT_KEEPALIVE = 50  # Seconds, it appears the server will disconnect after 60s idle
-FASTPOLL_TIMEOUT = 900 - 3  # seconds
-FASTPOLL_RETRY = 60  # if no messages after this time, retry fastpoll request
-FASTPOLL_RETRY_COUNT = 3
+
+# in seconds, how long to until the fastpoll request has timed out and a new one needs to be made
+FASTPOLL_TIMEOUT_SEC = 900 - 3  # seconds
+
+# in seconds, how long to wait for a message before retrying fastpoll or reconnecting
+MESSAGE_TIMEOUT_SEC = 60
+
+# number of times a message timeout can occur before just reconnecting
+MESSAGE_TIMEOUT_RETRY_COUNT = 3
 
 # in minutes, minimum amount of time to wait before retrying connection on forever loop
 FOREVER_RETRY_BASE_MIN_MINUTES = 1
@@ -26,4 +34,5 @@ FOREVER_RETRY_BASE_MIN_MINUTES = 1
 # in minutes, maximum amount of time to wait before trying connection on forever loop
 FOREVER_RETRY_BASE_MAX_MINUTES = 60
 
-DEFAULT_TIMEOUT = 10  # seconds
+# in seconds, how long to wait for a connection before timing out
+CONNECT_TIMEOUT_SEC = 60

--- a/src/pyduke_energy/errors.py
+++ b/src/pyduke_energy/errors.py
@@ -1,5 +1,8 @@
 """Error Types."""
 
+from typing import Any, Union
+import paho.mqtt.client as mqtt
+
 
 class DukeEnergyError(Exception):
     """Base error."""
@@ -11,3 +14,25 @@ class RequestError(DukeEnergyError):
 
 class InputError(DukeEnergyError):
     """Error for input issues."""
+
+
+class MqttError(DukeEnergyError):
+    """Error for issues relating to the MQTT connection."""
+
+
+class MqttCodeError(MqttError):
+    """Error for MQTT issues associated with an error code."""
+
+    def __init__(self, operation: str, code: Union[int, mqtt.ReasonCodes], *args: Any):
+        super().__init__(*args)
+        self.operation = operation
+        self.code = code
+
+    def __str__(self) -> str:
+        """Output a formatted string for the error code."""
+        if isinstance(self.code, mqtt.ReasonCodes):
+            return f"{self.operation}: ({self.code.value}) {str(self.code)}"
+        elif isinstance(self.code, int):
+            return f"{self.operation}: ({self.code}) {mqtt.error_string(self.code)}"
+        else:
+            return f"{self.operation}: ({self.code}) {super().__str__()}"

--- a/src/pyduke_energy/errors.py
+++ b/src/pyduke_energy/errors.py
@@ -1,6 +1,7 @@
 """Error Types."""
 
 from typing import Any, Union
+
 import paho.mqtt.client as mqtt
 
 
@@ -32,7 +33,6 @@ class MqttCodeError(MqttError):
         """Output a formatted string for the error code."""
         if isinstance(self.code, mqtt.ReasonCodes):
             return f"{self.operation}: ({self.code.value}) {str(self.code)}"
-        elif isinstance(self.code, int):
+        if isinstance(self.code, int):
             return f"{self.operation}: ({self.code}) {mqtt.error_string(self.code)}"
-        else:
-            return f"{self.operation}: ({self.code}) {super().__str__()}"
+        return f"{self.operation}: ({self.code}) {super().__str__()}"

--- a/src/pyduke_energy/realtime.py
+++ b/src/pyduke_energy/realtime.py
@@ -10,7 +10,7 @@ import json
 import logging
 import ssl
 import time
-from typing import Optional, Any, Dict
+from typing import Any, Dict, Optional
 
 import paho.mqtt.client as mqtt
 
@@ -24,7 +24,7 @@ from pyduke_energy.const import (
     MQTT_KEEPALIVE,
     MQTT_PORT,
 )
-from pyduke_energy.errors import MqttCodeError, RequestError, MqttError
+from pyduke_energy.errors import MqttCodeError, MqttError, RequestError
 from pyduke_energy.types import RealtimeUsageMeasurement
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,10 +36,10 @@ class DukeEnergyRealtime:
     def __init__(self, duke_energy: DukeEnergyClient):
         self.duke_energy = duke_energy
         self.loop = asyncio.get_event_loop()
-        self.disconnected: Optional[asyncio.Future[int]] = None
+        self.disconnected: Optional["asyncio.Future[int]"] = None
         self.disconnecting: bool = False
-        self.connected: Optional[asyncio.Future[int]] = None
-        self.rx_msg: Optional[asyncio.Future[int]] = None
+        self.connected: Optional["asyncio.Future[int]"] = None
+        self.rx_msg: Optional["asyncio.Future[int]"] = None
         self.tstart: int = 0
         self.msg_retry_count: int = 0
         self.forever_retry_count: int = 0
@@ -286,7 +286,7 @@ class DukeEnergyRealtime:
                     self.msg_retry_count = 0
                     self.forever_retry_count = 0
                 except asyncio.TimeoutError:
-                    self.retry_count += 1
+                    self.msg_retry_count += 1
                     if self.disconnected.done():
                         _LOGGER.debug(
                             "Unexpected disconnect detected, attemping reconnect"

--- a/src/pyduke_energy/realtime.py
+++ b/src/pyduke_energy/realtime.py
@@ -343,7 +343,6 @@ class DukeEnergyRealtime:
         if not res:
             _LOGGER.warning("Unsubscribe error: %s", mqtt.error_string(res))
         await self._disconnected
-        self._disconnected = self._loop.create_future()  # re-create the future
 
         # Update mqtt_auth and header info
         client_id = self._mqtt_auth["clientid"]
@@ -358,6 +357,12 @@ class DukeEnergyRealtime:
 
     async def _async_mqtt_client_connect(self):
         """Run connect() in an async safe manner to avoid blocking."""
+        # Re-create the futures
+        if self._disconnected.done():
+            self._disconnected = self._loop.create_future()
+        if self._connected.done():
+            self._connected = self._loop.create_future()
+
         # Run connect() within an executor thread, since it blocks on socket
         # connection for up to `keepalive` seconds: https://git.io/Jt5Yc
         try:

--- a/tox.ini
+++ b/tox.ini
@@ -18,12 +18,18 @@ commands =
 
 [testenv:lint]
 basepython = python3
+allowlist_externals =
+    black
+    flake8
+    pylint
+    pydocstyle
+    isort
 commands =
     black .
     flake8 src/pyduke_energy tests
-    pylint src/pyduke_energy tests
     pydocstyle src/pyduke_energy tests
     isort src/pyduke_energy tests
+    pylint src/pyduke_energy tests
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Somewhat larger realtime factoring plus improvements to support more graceful error handling and indefinite reconnecting

A highlight of realtime client changes include
* **Breaking** Update external interface by renaming callback functions to be fully named (e.g. `on_msg` -> `on_message`). This is a breaking change and the main reason for a major version update.
* Create a new `MqttError` class that will wrap MQTT related exceptions, and make sure these exceptions are thrown in failure instances as opposed to suppressing them
* Update `connect_and_subscribe` to be callable multiple times
* Implement `connect_and_subscribe_forever` as a wrapper around `connect_and_subscribe` which will attempt to auto-recover from any disconnections with an exponential back-off strategy
* Add new `connected` future which will trigger when `on_connect` is called. This allows us to do a timeout wait and detect when connection is never achieved.
* Add more type hints to help with type safety
* Miscellaneous linting fixes

Plus some changes to development
* Run build and tests on pushes to all branches, not just main
* Update tox file to handle deprecation errors
