### PR TITLE
add primary and related bp number on account-details call

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pyduke-energy
-version = 1.0.1
+version = 1.0.2
 author = Michael Meli
 author_email = mjmeli94@gmail.com
 description = Python Wrapper for unofficial Duke Energy REST API

--- a/src/pyduke_energy/client.py
+++ b/src/pyduke_energy/client.py
@@ -105,7 +105,7 @@ class DukeEnergyClient:
             "GET", CUST_API_BASE_URL, ACCT_ENDPOINT, headers=headers, params=params
         )
         account_list: List[dict] = resp.get("accounts")
-        return [Account(acc) for acc in account_list]
+        return [Account(acc, resp) for acc in account_list]
 
     async def get_account_details(self, account: Account) -> AccountDetails:
         """Get detailed account data for a specific account."""
@@ -113,7 +113,8 @@ class DukeEnergyClient:
             account.src_sys_cd,
             account.src_acct_id,
             account.src_acct_id_2,
-            account.bp_number,
+            account.primary_bp_number,
+            account.related_bp_number,
         )
 
     async def _get_account_details(
@@ -121,7 +122,8 @@ class DukeEnergyClient:
         src_sys_cd: str,
         src_acct_id: str,
         src_acct_id_2: Optional[str],
-        bp_number: Optional[str],
+        primary_bp_number: Optional[str],
+        related_bp_number: Optional[str],
     ) -> AccountDetails:
         headers = await self._get_oauth_headers()
         params = {
@@ -131,8 +133,10 @@ class DukeEnergyClient:
         }
         if src_acct_id_2:
             params["srcAcctId2"] = src_acct_id_2
-        if bp_number:
-            params["bpNumber"] = bp_number
+        if primary_bp_number:
+            params["primaryBpNumber"] = primary_bp_number
+        if related_bp_number:
+            params["relatedBpNumber"] = related_bp_number
         resp = await self._async_request(
             "GET", CUST_API_BASE_URL, ACCT_DET_ENDPOINT, headers=headers, params=params
         )

--- a/src/pyduke_energy/types.py
+++ b/src/pyduke_energy/types.py
@@ -10,18 +10,21 @@ from pyduke_energy.utils import str_to_date, str_to_datetime, utc_timestamp_to_d
 class Account:
     """An account as provided by account-list endpoint."""
 
-    def __init__(self, data: dict):
+    def __init__(self, data: dict, common_data: dict):
         self.default_account: bool = data.get("defaultAccount")
         self.nickname: str = data.get("nickname")
         self.account_number: str = data.get("accountNumber")
         self.src_acct_id: str = data.get("srcAcctId")
         self.src_acct_id_2: str = data.get("srcAcctId2")
         self.src_sys_cd: str = data.get("srcSysCd")
-        self.bp_number: str = data.get("primaryBpNumber")
+        self.primary_bp_number: str = data.get("primaryBpNumber")
         self.status: str = data.get("status")
         self.role: str = data.get("role")
         self.service_address: str = data.get("serviceAddress")
         self.mobile_app_compatible: bool = data.get("mobileAppCompatible")
+
+        # Data common to all accounts
+        self.related_bp_number: str = common_data.get("relatedBpNumber")
 
 
 @dataclass

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 [flake8]
 max-line-length = 88
 select = C,E,F,W,B,B950
-extend-ignore = E203, E501
+extend-ignore = E203, E501, W503
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
 doctests = True
 


### PR DESCRIPTION
The account-details call has been hitting 400 errors recently. after some debugging I found that the actual call made by the app has the parameters primaryBpNumber and relatedBpNumber (available in the account-list call made previously), while the call being made by this library was just adding a single bpNumber parameter. It appeared that adding both of these parameters resolved the 400 errors.