### PR TITLE
give up when MQTT fails to reconnect more than 10 times

### DIFF
--- a/src/pyduke_energy/const.py
+++ b/src/pyduke_energy/const.py
@@ -5,12 +5,16 @@ CUST_PILOT_API_BASE_URL = "https://cust-pilot-api.duke-energy.com/"
 IOT_API_BASE_URL = "https://app-core1.de-iot.io/rest/cloud/"
 FASTPOLL_ENDPOINT = "smartmeter/fastpoll/start"
 OAUTH_ENDPOINT = "auth/oauth2/token"
-BASIC_AUTH = "Basic NEdtR3J1M085TEFIV3BMNjVjbWpyZDhtQ1VKZU5XTVo6OWFyZVZoZlM3R2N4UmgzWA=="  # hard-coded from Android app
 SMARTMETER_AUTH_ENDPOINT = "smartmeter/v1/auth"
 ACCT_ENDPOINT = "auth/account-list"
 ACCT_DET_ENDPOINT = "auth/account-details"
 GW_STATUS_ENDPOINT = "gw/gateways/status"
 GW_USAGE_ENDPOINT = "smartmeter/usageByHour"
+
+# hard-coded from Android app
+BASIC_AUTH = (
+    "Basic NEdtR3J1M085TEFIV3BMNjVjbWpyZDhtQ1VKZU5XTVo6OWFyZVZoZlM3R2N4UmgzWA=="
+)
 
 DEFAULT_TIMEOUT = 10  # seconds
 
@@ -27,6 +31,9 @@ MESSAGE_TIMEOUT_SEC = 60
 
 # number of times a message timeout can occur before just reconnecting
 MESSAGE_TIMEOUT_RETRY_COUNT = 3
+
+# number of times a message timeout can occur before we totally give up
+MESSAGE_TIMEOUT_GIVE_UP_COUNT = 10
 
 # in minutes, minimum amount of time to wait before retrying connection on forever loop
 FOREVER_RETRY_MIN_MINUTES = 1


### PR DESCRIPTION
Relates to mjmeli/ha-duke-energy-gateway/issues/153 where requesting smart poll is not reinitiating the MQTT stream, so trigger a full failure and let a full reconnect happen